### PR TITLE
feature: add support for lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Lagoon is nowhere near being feature complete or syntax complete. Below is a sma
 * [x] `>`, `>=`, `<`, `<=` - Mathematical comparison operators
 * [x] `**` - Exponent / power operator
 * [ ] `&`, `|`, `^`, `~`, `<<`, `>>` - Bitwise operators
-* [ ] Lists
+* [x] Lists
 * [ ] `for..in` statements
 * [ ] `in`, `not in` operators
 * [ ] Scalar objects (methods on scalar types)

--- a/examples/lists.lag
+++ b/examples/lists.lag
@@ -1,0 +1,1 @@
+let names = ["Ryan", "John", "Jane"]

--- a/examples/lists.lag
+++ b/examples/lists.lag
@@ -1,3 +1,4 @@
 let names = ["Ryan", "John", "Jane"]
 
 println(names)
+println(names[0])

--- a/examples/lists.lag
+++ b/examples/lists.lag
@@ -3,3 +3,7 @@ let names = ["Ryan", "John", "Jane"]
 println(names)
 
 println(names[0])
+
+names[0] = "Jim"
+
+println(names[0])

--- a/examples/lists.lag
+++ b/examples/lists.lag
@@ -1,1 +1,3 @@
 let names = ["Ryan", "John", "Jane"]
+
+println(names)

--- a/examples/lists.lag
+++ b/examples/lists.lag
@@ -6,4 +6,10 @@ println(names[0])
 
 names[0] = "Jim"
 
-println(names[0])
+let name = names[0]
+
+println(name)
+
+names[] = "Nora"
+
+println(names)

--- a/examples/lists.lag
+++ b/examples/lists.lag
@@ -1,4 +1,5 @@
 let names = ["Ryan", "John", "Jane"]
 
 println(names)
+
 println(names[0])

--- a/examples/lists.lag
+++ b/examples/lists.lag
@@ -13,3 +13,14 @@ println(name)
 names[] = "Nora"
 
 println(names)
+
+let nested = [
+    ["Ryan", "ryan@test.com"],
+    ["John", "john@test.com"]
+]
+
+println(nested)
+
+nested[0][0] = "James"
+
+println(nested)

--- a/examples/structs.lag
+++ b/examples/structs.lag
@@ -10,3 +10,20 @@ Person.new = fn (name, email) {
 let person = Person.new("Ryan", "ryan@test.com")
 
 println(person.name)
+
+struct Nested {
+    person
+}
+
+let nested = Nested {
+    person: Person {
+        name: "Ryan",
+        email: "ryan@test.com",
+    }
+}
+
+println(nested.person.name)
+
+nested.person.name = "James"
+
+println(nested.person.name)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -54,6 +54,7 @@ pub enum Expression {
     Struct(Box<Expression>, HashMap<Identifier, Expression>),
     Closure(Vec<Parameter>, Vec<Statement>),
     Get(Box<Expression>, Identifier),
+    Index(Box<Expression>, Box<Expression>),
     List(Vec<Expression>),
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -54,6 +54,7 @@ pub enum Expression {
     Struct(Box<Expression>, HashMap<Identifier, Expression>),
     Closure(Vec<Parameter>, Vec<Statement>),
     Get(Box<Expression>, Identifier),
+    List(Vec<Expression>),
 }
 
 impl Expression {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -54,7 +54,7 @@ pub enum Expression {
     Struct(Box<Expression>, HashMap<Identifier, Expression>),
     Closure(Vec<Parameter>, Vec<Statement>),
     Get(Box<Expression>, Identifier),
-    Index(Box<Expression>, Box<Expression>),
+    Index(Box<Expression>, Option<Box<Expression>>),
     List(Vec<Expression>),
 }
 

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -52,6 +52,7 @@ pub enum Value {
         environment: Rc<RefCell<Environment>>,
         definition: Box<Value>,
     },
+    List(Rc<RefCell<Vec<Value>>>),
     Function {
         name: String,
         params: Vec<Parameter>,

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -2,6 +2,7 @@ use hashbrown::HashMap;
 use std::fmt::{Debug, Formatter, Result};
 use std::rc::Rc;
 use std::cell::RefCell;
+use std::iter::Iterator;
 
 use crate::interpreter::Interpreter;
 use crate::ast::{Block, Parameter, Expression};
@@ -97,6 +98,21 @@ impl Debug for Value {
 
                 fields
             },
+            Value::List(items) => {
+                let mut buffer = String::from("[");
+                let items = items.borrow();
+
+                for (i, item) in items.iter().enumerate() {
+                    buffer.push_str(&item.clone().to_string());
+
+                    if i != items.len() - 1 {
+                        buffer.push_str(", ");
+                    }
+                }
+
+                buffer.push_str("]");
+                buffer
+            },
             Value::Bool(true) => "true".to_string(),
             Value::Bool(false) => "false".to_string(),
             _ => todo!(),
@@ -126,7 +142,7 @@ impl Value {
             Value::Number(n) => n.to_string(),
             Value::Bool(_) => self.to_number().to_string(),
             Value::Null => "".to_string(),
-            v @ Value::Function { .. } | v @ Value::StructInstance { .. } => format!("{:?}", v),
+            v @ Value::Function { .. } | v @ Value::StructInstance { .. } | v @ Value::List(..) => format!("{:?}", v),
             _ => todo!(),
         }
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -170,6 +170,11 @@ impl<'i> Interpreter<'i> {
                     _ => todo!()
                 }
             },
+            Expression::List(items) => {
+                let items = items.into_iter().map(|i| self.run_expression(i)).collect::<Vec<Value>>();
+
+                Value::List(Rc::new(RefCell::new(items)))
+            },
             Expression::Closure(params, body) => {
                 Value::Function {
                     name: String::from("Closure"),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -120,6 +120,20 @@ impl<'i> Interpreter<'i> {
                     }
                 }
             },
+            Expression::Index(target, index) => {
+                let instance = self.run_expression(*target);
+                let index = self.run_expression(*index).to_number() as usize;
+
+                match instance {
+                    Value::List(items) => {
+                        match items.borrow().get(index) {
+                            Some(v) => v.clone(),
+                            None => panic!("Undefined index: {}", index)
+                        }
+                    },
+                    _ => unreachable!()
+                }
+            },
             Expression::Get(target, field) => {
                 let instance = self.run_expression(*target.clone());
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -122,7 +122,7 @@ impl<'i> Interpreter<'i> {
             },
             Expression::Index(target, index) => {
                 let instance = self.run_expression(*target);
-                let index = self.run_expression(*index).to_number() as usize;
+                let index = self.run_expression(*index.expect("Expected index.")).to_number() as usize;
 
                 match instance {
                     Value::List(items) => {
@@ -309,14 +309,20 @@ impl<'i> Interpreter<'i> {
 
                 match *target.clone() {
                     Expression::Index(instance, index) => {
-                        let index = self.run_expression(*index).to_number();
-
                         match self.run_expression(*instance) {
                             Value::List(items) => {
-                                items.borrow_mut().insert(index as usize, value.clone());
+                                match index {
+                                    Some(i) => {
+                                        let index = self.run_expression(*i).to_number();
+                                        items.borrow_mut().insert(index as usize, value.clone());
+                                    },
+                                    None => {
+                                        items.borrow_mut().push(value.clone());
+                                    }
+                                }
                             },
-                            _ => panic!("You can only assign to indexes on lists.")
-                        }
+                            _ => panic!("You can only assign and append items to lists.")
+                        };
                     },
                     Expression::Get(instance, field) => {
                         match self.run_expression(*instance) {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -314,7 +314,7 @@ impl<'i> Interpreter<'i> {
                                 match index {
                                     Some(i) => {
                                         let index = self.run_expression(*i).to_number();
-                                        items.borrow_mut().insert(index as usize, value.clone());
+                                        items.borrow_mut()[index as usize] = value.clone();
                                     },
                                     None => {
                                         items.borrow_mut().push(value.clone());

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -308,6 +308,16 @@ impl<'i> Interpreter<'i> {
                 let value = self.run_expression(*value);
 
                 match *target.clone() {
+                    Expression::Index(instance, index) => {
+                        let index = self.run_expression(*index).to_number();
+
+                        match self.run_expression(*instance) {
+                            Value::List(items) => {
+                                items.borrow_mut().insert(index as usize, value.clone());
+                            },
+                            _ => panic!("You can only assign to indexes on lists.")
+                        }
+                    },
                     Expression::Get(instance, field) => {
                         match self.run_expression(*instance) {
                             // TODO: Check if the field exists on the definition before

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,5 +15,7 @@ fn main() {
     let tokens = token::generate(contents.as_str());
     let ast = parser::parse(tokens).unwrap();
 
+    dbg!(ast.clone());
+
     interpreter::interpret(ast);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -175,11 +175,15 @@ impl<'p> Parser<'p> {
             Token::LeftBracket => {
                 self.expect_token_and_read(Token::LeftBracket)?;
 
-                let index = self.parse_expression(Precedence::Lowest)?;
+                let index: Option<Box<Expression>> = if self.current_is(Token::RightBracket) {
+                    None
+                } else {
+                    Some(self.parse_expression(Precedence::Lowest)?.boxed())
+                };
 
                 self.expect_token_and_read(Token::RightBracket)?;
 
-                Some(Expression::Index(left.boxed(), index.boxed()))
+                Some(Expression::Index(left.boxed(), index))
             },
             Token::LeftBrace => {
                 self.expect_token_and_read(Token::LeftBrace)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -40,7 +40,7 @@ impl Precedence {
         match token {
             Token::Asterisk | Token::Slash => Self::Product,
             Token::Plus | Token::Minus => Self::Sum,
-            Token::LeftParen | Token::Dot => Self::Call,
+            Token::LeftParen | Token::Dot | Token::LeftBracket => Self::Call,
             Token::LessThan | Token::GreaterThan | Token::LessThanOrEquals | Token::GreaterThanOrEquals => Self::LessThanGreaterThan,
             Token::Equals | Token::NotEquals => Self::Equals,
             Token::And | Token::Or => Self::AndOr,
@@ -176,6 +176,8 @@ impl<'p> Parser<'p> {
                 self.expect_token_and_read(Token::LeftBracket)?;
 
                 let index = self.parse_expression(Precedence::Lowest)?;
+
+                self.expect_token_and_read(Token::RightBracket)?;
 
                 Some(Expression::Index(left.boxed(), index.boxed()))
             },

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -172,6 +172,13 @@ impl<'p> Parser<'p> {
 
                 Some(Expression::Get(Box::new(left), field))
             },
+            Token::LeftBracket => {
+                self.expect_token_and_read(Token::LeftBracket)?;
+
+                let index = self.parse_expression(Precedence::Lowest)?;
+
+                Some(Expression::Index(left.boxed(), index.boxed()))
+            },
             Token::LeftBrace => {
                 self.expect_token_and_read(Token::LeftBrace)?;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -130,6 +130,23 @@ impl<'p> Parser<'p> {
 
                 Expression::Prefix(Op::token(t), self.parse_expression(Precedence::Prefix)?.boxed())
             },
+            Token::LeftBracket => {
+                self.expect_token_and_read(Token::LeftBracket)?;
+
+                let mut items: Vec<Expression> = Vec::new();
+
+                while ! self.current_is(Token::RightBracket) {
+                    items.push(self.parse_expression(Precedence::Lowest)?);
+
+                    if self.current_is(Token::Comma) {
+                        self.expect_token_and_read(Token::Comma)?;
+                    }
+                }
+
+                self.expect_token_and_read(Token::RightBracket)?;
+
+                Expression::List(items)
+            },
             _ => todo!("{:?}", self.current.clone())
         };
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -61,6 +61,10 @@ pub enum Token {
     LeftBrace,
     #[token("}")]
     RightBrace,
+    #[token("[")]
+    LeftBracket,
+    #[token("]")]
+    RightBracket,
 
     #[token("+")]
     Plus,


### PR DESCRIPTION
This pull request adds support for lists (arrays).

A list can be created using `[]` tokens:

```rust
let items = ["Ryan", "John", "Jane"]
```

You can retrieve an item from the list at a particular index using the postfix index notation:

```rust
let ryan = items[0]
```

Lists are not limited to one type of data, you can use any type of data.

If you wish to assign a new value to a particular index, you can use the postfix index notation on the left hand side of an assignment expression:

```rust
items[1] = "Jimmy"
```

If you wish to append an item to the list, use the postfix index notation with an empty index:

```rust
items[] = "Nora"
```