### PR TITLE
feature: for..in

### DIFF
--- a/examples/for-in.lag
+++ b/examples/for-in.lag
@@ -3,3 +3,7 @@ let names = ["Ryan", "John", "Jane"]
 for name in names {
     println(name)
 }
+
+for (i, name) in names {
+    println(i + ". " + name)
+}

--- a/examples/for-in.lag
+++ b/examples/for-in.lag
@@ -1,0 +1,5 @@
+let names = ["Ryan", "John", "Jane"]
+
+for name in names {
+    println(name)
+}

--- a/examples/say_hello.lag
+++ b/examples/say_hello.lag
@@ -1,5 +1,5 @@
 fn say_hello(name) {
-    println($"Hello, {name}")
+    println("Hello, " + name)
 }
 
 say_hello("Ryan")

--- a/examples/strings.lag
+++ b/examples/strings.lag
@@ -1,5 +1,3 @@
 let name = "Ryan"
 
-println($"Hello, {name}")
-
-println($"1 + 1 is {1 + 1}")
+println(name)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -29,6 +29,12 @@ pub enum Statement {
         then: Block,
         otherwise: Option<Block>
     },
+    For {
+        iterable: Expression,
+        value: Identifier,
+        index: Option<Identifier>,
+        then: Block,
+    },
     Expression {
         expression: Expression,
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -49,7 +49,6 @@ pub struct Parameter {
 pub enum Expression {
     Number(f64),
     String(String),
-    InterpolatedString(String),
     Bool(bool),
     Null,
     Identifier(Identifier),

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -33,6 +33,10 @@ impl Environment {
         }
     }
 
+    pub fn drop(&mut self, name: impl Into<String>) {
+        self.values.remove(&name.into());
+    }
+
     pub fn dump(&self) {
         dbg!(self.values.clone());
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -91,7 +91,16 @@ impl<'p> Parser<'p> {
     fn parse_for(&mut self) -> Result<Statement, ParseError> {
         self.expect_token_and_read(Token::For)?;
 
-        let (index, value) = (None, self.expect_identifier_and_read()?.into());
+        let (index, value) = if self.current_is(Token::LeftParen) {
+            self.expect_token_and_read(Token::LeftParen)?;
+            let index = self.expect_identifier_and_read()?;
+            self.expect_token_and_read(Token::Comma)?;
+            let tuple = (Some(index.into()), self.expect_identifier_and_read()?.into());
+            self.expect_token_and_read(Token::RightParen)?;
+            tuple
+        } else {
+            (None, self.expect_identifier_and_read()?.into())
+        };
 
         self.expect_token_and_read(Token::In)?;
 
@@ -110,10 +119,6 @@ impl<'p> Parser<'p> {
             Token::Null => {
                 self.expect_token_and_read(Token::Null)?;
                 Expression::Null
-            },
-            Token::InterpolatedString(s) => {
-                self.expect_token_and_read(Token::InterpolatedString("".to_string()))?;
-                Expression::InterpolatedString(s.to_string())
             },
             Token::Number(n) => {
                 self.expect_token_and_read(Token::Number(0.0))?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -74,6 +74,7 @@ impl<'p> Parser<'p> {
             Token::Struct => self.parse_struct(),
             Token::Let => self.parse_let(),
             Token::If => self.parse_if(),
+            Token::For => self.parse_for(),
             Token::Return => {
                 self.expect_token_and_read(Token::Return)?;
 
@@ -85,6 +86,19 @@ impl<'p> Parser<'p> {
             },
             _ => Ok(Statement::Expression{ expression: self.parse_expression(Precedence::Lowest)? }),
         }
+    }
+
+    fn parse_for(&mut self) -> Result<Statement, ParseError> {
+        self.expect_token_and_read(Token::For)?;
+
+        let (index, value) = (None, self.expect_identifier_and_read()?.into());
+
+        self.expect_token_and_read(Token::In)?;
+
+        let iterable = self.parse_expression(Precedence::Statement)?;
+        let then = self.parse_block()?;
+
+        Ok(Statement::For { index, value, iterable, then })
     }
 
     fn parse_expression(&mut self, precedence: Precedence) -> Result<Expression, ParseError> {

--- a/src/token.rs
+++ b/src/token.rs
@@ -42,6 +42,10 @@ pub enum Token {
     While,
     #[token("return")]
     Return,
+    #[token("for")]
+    For,
+    #[token("in")]
+    In,
 
     #[regex(r"[a-zA-Z_?]+", to_string)]
     Identifier(String),

--- a/src/token.rs
+++ b/src/token.rs
@@ -54,8 +54,6 @@ pub enum Token {
     Number(f64),
     #[regex(r##""(?:[^"\\]|\\.)*""##, to_string)]
     String(String),
-    #[regex(r##"\$"(?:[^"\\]|\\.)*""##, to_string)]
-    InterpolatedString(String),
 
     #[token("(")]
     LeftParen,
@@ -198,12 +196,5 @@ mod tests {
         assert_eq!(lexer.next(), Some(Token::String(r##"testing"##.to_owned())));
         assert_eq!(lexer.next(), Some(Token::String(r##"testing with \""##.to_owned())));
         assert_eq!(lexer.next(), Some(Token::String(r##"testing \n"##.to_owned())));
-    }
-
-    #[test]
-    fn it_can_recognise_interpolated_strings() {
-        let mut lexer = Token::lexer(r##"$"testing""##);
-
-        assert_eq!(lexer.next(), Some(Token::InterpolatedString(r##"testing"##.to_owned())));
     }
 }


### PR DESCRIPTION
Adds support for `for..in` statements.

At the moment, the only iterable value is the new list value. (#1)

In the future, I'll likely add support for iterating over strings too. Or perhaps a `.chars()` method on the `string` type that returns a list is smarter.

```rust
let names = ["Ryan"]

for name in names {

}

for (i, name) in names {

}
```