### PR TITLE
feature: `in` / `not in`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Lagoon is nowhere near being feature complete or syntax complete. Below is a sma
 * [ ] `&`, `|`, `^`, `~`, `<<`, `>>` - Bitwise operators
 * [x] Lists
 * [x] `for..in` statements
-* [ ] `in`, `not in` operators
+* [x] `in`, `not in` operators
 * [ ] Scalar objects (methods on scalar types)
 * [ ] Module system
 * [ ] Standard Library

--- a/examples/in.lag
+++ b/examples/in.lag
@@ -1,0 +1,21 @@
+let names = ["Ryan", "Jane"]
+
+if "Ryan" in names {
+    println("Ryan is present")
+}
+
+if "Jane" in names {
+    println("Jane is present")
+}
+
+if "John" not in names {
+    println("John is not present")
+}
+
+if "J" in "John" { 
+    println("J exists inside of John")
+}
+
+if "C" not in "John" {
+    println("C does not exist inside of John")
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -91,6 +91,8 @@ pub enum Op {
     And,
     Or,
     Pow,
+    In,
+    NotIn,
 }
 
 impl Op {
@@ -112,6 +114,8 @@ impl Op {
             Token::And => Self::And,
             Token::Or => Self::Or,
             Token::Pow => Self::Pow,
+            Token::In => Self::In,
+            Token::NotIn => Self::NotIn,
             _ => unreachable!("{:?}", token)
         }
     }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -164,7 +164,11 @@ impl Value {
     pub fn is(self, other: Value) -> bool {
         match (self, other) {
             (Value::String(l), r) => l == r.to_string(),
-            _ => unimplemented!()
+            (Value::Number(n), r) => n == r.to_number(),
+            (Value::Bool(true), r) => r.to_bool() == true,
+            (Value::Bool(false), r) => r.to_bool() == false,
+            (Value::Null, Value::Null) => true,
+            _ => false,
         }
     }
 }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -153,9 +153,8 @@ impl Value {
 
     pub fn to_bool(self) -> bool {
         match self {
-            Value::Bool(true) => true,
+            Value::Bool(true) | Value::Function { .. } => true,
             Value::String(s) => !s.is_empty(),
-            Value::Function { .. } => true,
             Value::Number(n) => n > 0.0,
             _ => false,
         }

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -160,4 +160,11 @@ impl Value {
             _ => false,
         }
     }
+
+    pub fn is(self, other: Value) -> bool {
+        match (self, other) {
+            (Value::String(l), r) => l == r.to_string(),
+            _ => unimplemented!()
+        }
+    }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -200,6 +200,32 @@ impl<'i> Interpreter<'i> {
                     (l, Op::And, r) => Value::Bool(l.to_bool() && r.to_bool()),
                     (l, Op::Or, r) => Value::Bool(l.to_bool() || r.to_bool()),
                     (Value::Number(l), Op::Pow, Value::Number(r)) => Value::Number(l.powf(r)),
+                    (l, Op::In, Value::List(r)) => {
+                        let filtered: Vec<Value> = r.borrow().clone()
+                            .into_iter()
+                            .filter(|v| {
+                                v.clone().is(l.clone())
+                            })
+                            .collect();
+
+                        Value::Bool(! filtered.is_empty())
+                    },
+                    (Value::String(l), Op::In, Value::String(r)) => {
+                        Value::Bool(r.contains(l.as_str()))
+                    },
+                    (l, Op::NotIn, Value::List(r)) => {
+                        let filtered: Vec<Value> = r.borrow().clone()
+                            .into_iter()
+                            .filter(|v| {
+                                v.clone().is(l.clone())
+                            })
+                            .collect();
+
+                        Value::Bool(filtered.is_empty())
+                    },
+                    (Value::String(l), Op::NotIn, Value::String(r)) => {
+                        Value::Bool(! r.contains(l.as_str()))
+                    },
                     _ => todo!()
                 }
             },

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -43,7 +43,7 @@ impl Precedence {
             Token::LeftParen | Token::Dot | Token::LeftBracket => Self::Call,
             Token::LessThan | Token::GreaterThan | Token::LessThanOrEquals | Token::GreaterThanOrEquals => Self::LessThanGreaterThan,
             Token::Equals | Token::NotEquals => Self::Equals,
-            Token::And | Token::Or => Self::AndOr,
+            Token::And | Token::Or | Token::In | Token::NotIn => Self::AndOr,
             Token::Assign => Self::Assign,
             Token::LeftBrace => Self::Statement,
             Token::Pow => Self::Pow,
@@ -256,7 +256,7 @@ impl<'p> Parser<'p> {
             Token::Plus | Token::Minus | Token::Asterisk | Token::Slash |
             Token::Equals | Token::NotEquals | Token::LessThanOrEquals | Token::LessThan |
             Token::GreaterThan | Token::GreaterThanOrEquals | Token::And | Token::Or |
-            Token::Pow => {
+            Token::Pow | Token::In | Token::NotIn => {
                 let token = self.current.clone();
 
                 self.read();

--- a/src/token.rs
+++ b/src/token.rs
@@ -46,6 +46,8 @@ pub enum Token {
     For,
     #[token("in")]
     In,
+    #[token("not in")]
+    NotIn,
 
     #[regex(r"[a-zA-Z_?]+", to_string)]
     Identifier(String),


### PR DESCRIPTION
Adds new `in` and `not in` infix operators.

Can currently be used to check if a list contains, or doesn't contain, a scalar value (anything but a struct or list).
Can also be used to check if a string contains, or doesn't contain, another string.