### PR TITLE
Feature/require

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Lagoon is nowhere near being feature complete or syntax complete. Below is a sma
 * [x] `for..in` statements
 * [x] `in`, `not in` operators
 * [x] Scalar objects (methods on scalar types)
-* [ ] Module system
+* [x] Module system
 * [x] Standard Library
 * [x] Nicer error reporting
 * [x] Transpile to JavaScript

--- a/crates/lagoon-interpreter/src/interpreter.rs
+++ b/crates/lagoon-interpreter/src/interpreter.rs
@@ -1,6 +1,8 @@
 use std::slice::Iter;
 use std::rc::Rc;
 use std::cell::{RefCell, Ref, RefMut};
+use std::path::PathBuf;
+use std::fs::canonicalize;
 use hashbrown::HashMap;
 use thiserror::Error;
 use colored::*;
@@ -8,8 +10,8 @@ use lagoon_parser::*;
 
 use crate::environment::*;
 
-pub fn interpret(ast: Program) -> Result<(), InterpreterResult> {
-    let mut interpreter = Interpreter::new(ast.iter());
+pub fn interpret(ast: Program, path: PathBuf) -> Result<(), InterpreterResult> {
+    let mut interpreter = Interpreter::new(ast.iter(), canonicalize(path).unwrap());
 
     interpreter.define_global_function("println", crate::stdlib::println);
     interpreter.define_global_function("print", crate::stdlib::print);
@@ -63,14 +65,16 @@ pub struct Interpreter<'i> {
     ast: Iter<'i, Statement>,
     environment: Rc<RefCell<Environment>>,
     globals: HashMap<String, Value>,
+    path: PathBuf,
 }
 
 impl<'i> Interpreter<'i> {
-    fn new(ast: Iter<'i, Statement>) -> Self {
+    fn new(ast: Iter<'i, Statement>, path: PathBuf) -> Self {
         Self {
             ast: ast,
             environment: Rc::new(RefCell::new(Environment::new())),
             globals: HashMap::new(),
+            path: path,
         }
     }
 

--- a/crates/lagoon-interpreter/src/interpreter.rs
+++ b/crates/lagoon-interpreter/src/interpreter.rs
@@ -10,12 +10,17 @@ use lagoon_parser::*;
 
 use crate::environment::*;
 
-pub fn interpret(ast: Program, path: PathBuf) -> Result<(), InterpreterResult> {
-    let mut interpreter = Interpreter::new(ast.iter(), canonicalize(path).unwrap());
-
+pub fn register_global_functions(interpreter: &mut Interpreter) {
     interpreter.define_global_function("println", crate::stdlib::println);
     interpreter.define_global_function("print", crate::stdlib::print);
     interpreter.define_global_function("type", crate::stdlib::r#type);
+    interpreter.define_global_function("require", crate::stdlib::require);
+}
+
+pub fn interpret(ast: Program, path: PathBuf) -> Result<(), InterpreterResult> {
+    let mut interpreter = Interpreter::new(ast.iter(), canonicalize(path).unwrap());
+
+    register_global_functions(&mut interpreter);
 
     interpreter.run()
 }
@@ -64,12 +69,12 @@ impl InterpreterResult {
 pub struct Interpreter<'i> {
     ast: Iter<'i, Statement>,
     environment: Rc<RefCell<Environment>>,
-    globals: HashMap<String, Value>,
+    pub globals: HashMap<String, Value>,
     path: PathBuf,
 }
 
 impl<'i> Interpreter<'i> {
-    fn new(ast: Iter<'i, Statement>, path: PathBuf) -> Self {
+    pub fn new(ast: Iter<'i, Statement>, path: PathBuf) -> Self {
         Self {
             ast: ast,
             environment: Rc::new(RefCell::new(Environment::new())),
@@ -164,6 +169,7 @@ impl<'i> Interpreter<'i> {
 
     pub fn call(&mut self, callable: Value, arguments: Vec<Value>) -> Result<Value, InterpreterResult> {
         Ok(match callable {
+            Value::Constant(v) => self.call(*v, arguments)?,
             Value::NativeFunction { callback, .. } => callback(self, arguments),
             Value::NativeMethod { callback, context, .. } => {
                 let context = self.run_expression(context)?;
@@ -311,7 +317,7 @@ impl<'i> Interpreter<'i> {
                     (Value::String(l), Op::NotIn, Value::String(r)) => {
                         Value::Bool(! r.contains(l.as_str()))
                     },
-                    _ => todo!()
+                    _ => todo!(),
                 }
             },
             Expression::List(items) => {
@@ -471,6 +477,10 @@ impl<'i> Interpreter<'i> {
         })
     }
 
+    pub fn path(&self) -> PathBuf {
+        self.path.clone()
+    }
+
     fn define_global_function(&mut self, name: impl Into<String>, callback: NativeFunctionCallback) {
         let name = name.into();
 
@@ -516,9 +526,19 @@ impl<'i> Interpreter<'i> {
         })
     }
 
+    pub fn exec(&mut self, ast: Program) -> Result<(), InterpreterResult> {
+        let mut ast = ast.into_iter();
+
+        while let Some(statement) = ast.next() {
+            self.run_statement(statement)?;
+        }
+
+        Ok(())
+    }
+
     fn run(&mut self) -> Result<(), InterpreterResult> {
         while let Some(statement) = self.ast.next() {
-            let _r = self.run_statement(statement.clone())?;
+            self.run_statement(statement.clone())?;
         }
 
         if ! ::std::env::args().filter(|a| a == "--debug").collect::<Vec<String>>().is_empty() {

--- a/crates/lagoon/src/main.rs
+++ b/crates/lagoon/src/main.rs
@@ -43,13 +43,13 @@ fn main() {
 
     if let Some(ref run) = matches.subcommand_matches("run") {
         let file = run.value_of("file").unwrap();
+        let path = std::path::PathBuf::from(file);
         let contents = read_to_string(file).unwrap();
         let tokens = generate(contents.as_str());
         
         match parse(tokens) {
             Ok(ast) => {
-                dbg!(ast.clone());
-                match interpret(ast) {
+                match interpret(ast, path) {
                     Ok(_) => {},
                     Err(e) => e.print(),
                 };

--- a/examples/module.lag
+++ b/examples/module.lag
@@ -1,0 +1,5 @@
+struct Math {}
+
+Math.pow = fn (left, right) {
+    return left ** right
+}

--- a/examples/require.lag
+++ b/examples/require.lag
@@ -1,0 +1,3 @@
+require("./module")
+
+println(Math.pow(2, 2))


### PR DESCRIPTION
Adds a native `require()` function that accepts a relative path.

The relative path should be relative to the current file.

It allows you to execute another file in the current context, meaning all functions, variables and structs are then available inside of the current context.

**Person.lag**
```
struct Person {
    name
}
```

**main.lag**
```
require("./Person")

const Ryan = Person { name: "Ryan" }
```

This is the simplest form of modules really. I'll likely try to implement an explicit export / import syntax in the future but this should help separate things for now.